### PR TITLE
Adding mac support

### DIFF
--- a/bin/g
+++ b/bin/g
@@ -296,7 +296,7 @@ done < "$TEMP/merged.branches"
 git for-each-ref --sort=-committerdate refs/remotes \
 --format='%(HEAD) %(color:green)%(committerdate:relative)%(color:reset)|%(color:red)%(objectname:short)%(color:reset)|%(color:blue)%(refname:short)%(color:reset)' > "$TEMP/remote.branches"
 # Print them in columns
-cat "$TEMP/local.branches" "$TEMP/remote.branches" | vl -s'\|'
+cat "$TEMP/local.branches" "$TEMP/remote.branches" | sed 's/|/\t/g'
 ;;
 
 fetch)


### PR DESCRIPTION
Using sed instead of vl for git branches since vl does not exist on MacOS.